### PR TITLE
Update ansible config to fix `ansible-lint` errors

### DIFF
--- a/roles/chrome/tasks/main.yml
+++ b/roles/chrome/tasks/main.yml
@@ -1,8 +1,9 @@
 ---
-- name: "Check for distribution config : {{ ansible_distribution }}"
+- name: "Check for distribution config : {{ ansible_facts['distribution'] }}"
   ansible.builtin.stat:
-    path: "{{ role_path }}/tasks/{{ ansible_distribution }}.yml"
-  register: distribution_config
-- name: "Run tasks : {{ ansible_distribution }}"
-  ansible.builtin.include_tasks: "{{ ansible_distribution }}.yml"
-  when: distribution_config.stat.exists
+    path: "{{ role_path }}/tasks/{{ ansible_facts['distribution'] }}.yml"
+  register: chrome_distribution_config
+
+- name: "Run tasks : {{ ansible_facts['distribution'] }}"
+  ansible.builtin.include_tasks: "{{ ansible_facts['distribution'] }}.yml"
+  when: chrome_distribution_config.stat.exists

--- a/roles/fnm/tasks/Ubuntu.yml
+++ b/roles/fnm/tasks/Ubuntu.yml
@@ -2,16 +2,16 @@
 - name: "Ubuntu : Check for latest version"
   ansible.builtin.uri:
     url: https://api.github.com/repos/Schniz/fnm/releases/latest
-  register: latest_version_response
+  register: fnm_latest_version_response
 - name: "Ubuntu : Set latest version"
   ansible.builtin.set_fact:
-    latest_version: "{{ latest_version_response.json.tag_name }}"
+    fnm_latest_version: "{{ fnm_latest_version_response.json.tag_name }}"
 - name: "Ubuntu : Download latest version"
   ansible.builtin.get_url:
-    url: "https://github.com/Schniz/fnm/releases/download/{{ latest_version }}/fnm-linux.zip"
-    dest: "/tmp/fnm-{{ latest_version }}-linux.zip"
+    url: "https://github.com/Schniz/fnm/releases/download/{{ fnm_latest_version }}/fnm-linux.zip"
+    dest: "/tmp/fnm-{{ fnm_latest_version }}-linux.zip"
     mode: "0644"
-  register: download_result
+  register: fnm_download_result
 - name: "Ubuntu : Create fnm directory"
   ansible.builtin.file:
     path: "{{ fnm_path }}"
@@ -22,8 +22,8 @@
     path: "{{ fnm_path }}/fnm"
   register: fnm_stat
 - name: "Ubuntu : Extract and install binary"
-  when: not fnm_stat.stat.exists or download_result.changed
+  when: not fnm_stat.stat.exists or fnm_download_result.changed
   ansible.builtin.unarchive:
-    src: "/tmp/fnm-{{ latest_version }}-linux.zip"
+    src: "/tmp/fnm-{{ fnm_latest_version }}-linux.zip"
     dest: "{{ fnm_path }}"
     remote_src: true

--- a/roles/fnm/tasks/main.yml
+++ b/roles/fnm/tasks/main.yml
@@ -1,8 +1,9 @@
 ---
-- name: "Check for distribution config : {{ ansible_distribution }}"
+- name: "Check for distribution config : {{ ansible_facts['distribution'] }}"
   ansible.builtin.stat:
-    path: "{{ role_path }}/tasks/{{ ansible_distribution }}.yml"
-  register: distribution_config
-- name: "Run tasks : {{ ansible_distribution }}"
-  ansible.builtin.include_tasks: "{{ ansible_distribution }}.yml"
-  when: distribution_config.stat.exists
+    path: "{{ role_path }}/tasks/{{ ansible_facts['distribution'] }}.yml"
+  register: fnm_distribution_config
+
+- name: "Run tasks : {{ ansible_facts['distribution'] }}"
+  ansible.builtin.include_tasks: "{{ ansible_facts['distribution'] }}.yml"
+  when: fnm_distribution_config.stat.exists

--- a/roles/fnm/vars/main.yml
+++ b/roles/fnm/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-fnm_path: "{{ ansible_user_dir }}/.local/share/fnm"
+fnm_path: "{{ ansible_facts['user_dir'] }}/.local/share/fnm"

--- a/roles/fzf/tasks/Ubuntu.yml
+++ b/roles/fzf/tasks/Ubuntu.yml
@@ -2,18 +2,18 @@
 - name: "Ubuntu : Check for latest version"
   ansible.builtin.uri:
     url: https://api.github.com/repos/junegunn/fzf/releases/latest
-  register: latest_version_response
+  register: fzf_latest_version_response
 - name: "Ubuntu : Set latest version"
   ansible.builtin.set_fact:
-    latest_version: "{{ latest_version_response.json.tag_name | regex_search('v([^v]*)', '\\1') | first }}"
+    fzf_latest_version: "{{ fzf_latest_version_response.json.tag_name | regex_search('v([^v]*)', '\\1') | first }}"
 - name: "Ubuntu : Download latest version"
   ansible.builtin.get_url:
-    url: "https://github.com/junegunn/fzf/releases/download/v{{ latest_version }}/fzf-{{ latest_version }}-linux_amd64.tar.gz"
-    dest: "/tmp/fzf-{{ latest_version }}.tar.gz"
+    url: "https://github.com/junegunn/fzf/releases/download/v{{ fzf_latest_version }}/fzf-{{ fzf_latest_version }}-linux_amd64.tar.gz"
+    dest: "/tmp/fzf-{{ fzf_latest_version }}.tar.gz"
     mode: "0644"
 - name: "Ubuntu : Extract and install binary"
   ansible.builtin.unarchive:
-    src: "/tmp/fzf-{{ latest_version }}.tar.gz"
+    src: "/tmp/fzf-{{ fzf_latest_version }}.tar.gz"
     dest: "/usr/local/bin"
     remote_src: true
   become: true

--- a/roles/fzf/tasks/main.yml
+++ b/roles/fzf/tasks/main.yml
@@ -1,8 +1,9 @@
 ---
-- name: "Check for distribution config : {{ ansible_distribution }}"
+- name: "Check for distribution config : {{ ansible_facts['distribution'] }}"
   ansible.builtin.stat:
-    path: "{{ role_path }}/tasks/{{ ansible_distribution }}.yml"
-  register: distribution_config
-- name: "Run tasks : {{ ansible_distribution }}"
-  ansible.builtin.include_tasks: "{{ ansible_distribution }}.yml"
-  when: distribution_config.stat.exists
+    path: "{{ role_path }}/tasks/{{ ansible_facts['distribution'] }}.yml"
+  register: fzf_distribution_config
+
+- name: "Run tasks : {{ ansible_facts['distribution'] }}"
+  ansible.builtin.include_tasks: "{{ ansible_facts['distribution'] }}.yml"
+  when: fzf_distribution_config.stat.exists

--- a/roles/ghostty/tasks/main.yml
+++ b/roles/ghostty/tasks/main.yml
@@ -1,8 +1,9 @@
 ---
-- name: "Check for distribution config : {{ ansible_distribution }}"
+- name: "Check for distribution config : {{ ansible_facts['distribution'] }}"
   ansible.builtin.stat:
-    path: "{{ role_path }}/tasks/{{ ansible_distribution }}.yml"
-  register: distribution_config
-- name: "Run tasks : {{ ansible_distribution }}"
-  ansible.builtin.include_tasks: "{{ ansible_distribution }}.yml"
-  when: distribution_config.stat.exists
+    path: "{{ role_path }}/tasks/{{ ansible_facts['distribution'] }}.yml"
+  register: ghostty_distribution_config
+
+- name: "Run tasks : {{ ansible_facts['distribution'] }}"
+  ansible.builtin.include_tasks: "{{ ansible_facts['distribution'] }}.yml"
+  when: ghostty_distribution_config.stat.exists

--- a/roles/ghostty/vars/main.yml
+++ b/roles/ghostty/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-ghostty_config_path: "{{ ansible_user_dir }}/.config/ghostty"
+ghostty_config_path: "{{ ansible_facts['user_dir'] }}/.config/ghostty"

--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -1,14 +1,14 @@
 ---
-- name: "Check for distribution config : {{ ansible_distribution }}"
+- name: "Check for distribution config : {{ ansible_facts['distribution'] }}"
   ansible.builtin.stat:
-    path: "{{ role_path }}/tasks/{{ ansible_distribution }}.yml"
-  register: distribution_config
-- name: "Run tasks : {{ ansible_distribution }}"
-  ansible.builtin.include_tasks: "{{ ansible_distribution }}.yml"
-  when: distribution_config.stat.exists
+    path: "{{ role_path }}/tasks/{{ ansible_facts['distribution'] }}.yml"
+  register: git_distribution_config
+- name: "Run tasks : {{ ansible_facts['distribution'] }}"
+  ansible.builtin.include_tasks: "{{ ansible_facts['distribution'] }}.yml"
+  when: git_distribution_config.stat.exists
 - name: "Link .gitconfig"
   ansible.builtin.file:
     src: "{{ role_path }}/files/.gitconfig"
-    dest: "{{ ansible_user_dir }}/.gitconfig"
+    dest: "{{ ansible_facts['user_dir'] }}/.gitconfig"
     state: link
     force: true

--- a/roles/hiddenbar/tasks/main.yml
+++ b/roles/hiddenbar/tasks/main.yml
@@ -1,8 +1,9 @@
 ---
-- name: "Check for distribution config : {{ ansible_distribution }}"
+- name: "Check for distribution config : {{ ansible_facts['distribution'] }}"
   ansible.builtin.stat:
-    path: "{{ role_path }}/tasks/{{ ansible_distribution }}.yml"
-  register: distribution_config
-- name: "Run tasks : {{ ansible_distribution }}"
-  ansible.builtin.include_tasks: "{{ ansible_distribution }}.yml"
-  when: distribution_config.stat.exists
+    path: "{{ role_path }}/tasks/{{ ansible_facts['distribution'] }}.yml"
+  register: hiddenbar_distribution_config
+
+- name: "Run tasks : {{ ansible_facts['distribution'] }}"
+  ansible.builtin.include_tasks: "{{ ansible_facts['distribution'] }}.yml"
+  when: hiddenbar_distribution_config.stat.exists

--- a/roles/karabiner/tasks/MacOSX.yml
+++ b/roles/karabiner/tasks/MacOSX.yml
@@ -9,19 +9,19 @@
     prompt: "Password"
     echo: false
   when: karabiner_cli_command_check.rc != 0
-  register: sudo_password
+  register: karabiner_sudo_password
 - name: "MacOSX : Install"
   community.general.homebrew_cask:
     name: karabiner-elements
-    sudo_password: "{{ sudo_password.user_input | default('') }}"
+    sudo_password: "{{ karabiner_sudo_password.user_input | default('') }}"
 - name: "MacOSX : Create config directory"
   ansible.builtin.file:
-    path: "{{ ansible_user_dir }}/.config"
+    path: "{{ ansible_facts['user_dir'] }}/.config"
     state: directory
     mode: "0755"
 - name: "MacOSX : Link config"
   ansible.builtin.file:
     src: "{{ role_path }}/files/karabiner"
-    dest: "{{ ansible_user_dir }}/.config/karabiner"
+    dest: "{{ ansible_facts['user_dir'] }}/.config/karabiner"
     state: link
     force: true

--- a/roles/karabiner/tasks/main.yml
+++ b/roles/karabiner/tasks/main.yml
@@ -1,8 +1,9 @@
 ---
-- name: "Check for distribution config : {{ ansible_distribution }}"
+- name: "Check for distribution config : {{ ansible_facts['distribution'] }}"
   ansible.builtin.stat:
-    path: "{{ role_path }}/tasks/{{ ansible_distribution }}.yml"
-  register: distribution_config
-- name: "Run tasks : {{ ansible_distribution }}"
-  ansible.builtin.include_tasks: "{{ ansible_distribution }}.yml"
-  when: distribution_config.stat.exists
+    path: "{{ role_path }}/tasks/{{ ansible_facts['distribution'] }}.yml"
+  register: karabiner_distribution_config
+
+- name: "Run tasks : {{ ansible_facts['distribution'] }}"
+  ansible.builtin.include_tasks: "{{ ansible_facts['distribution'] }}.yml"
+  when: karabiner_distribution_config.stat.exists

--- a/roles/lazygit/tasks/Ubuntu.yml
+++ b/roles/lazygit/tasks/Ubuntu.yml
@@ -2,18 +2,18 @@
 - name: "Ubuntu : Check for latest version"
   ansible.builtin.uri:
     url: https://api.github.com/repos/jesseduffield/lazygit/releases/latest
-  register: latest_version_response
+  register: lazygit_latest_version_response
 - name: "Ubuntu : Set latest version"
   ansible.builtin.set_fact:
-    latest_version: "{{ latest_version_response.json.tag_name | regex_search('v([^v]*)', '\\1') | first }}"
+    lazygit_latest_version: "{{ lazygit_latest_version_response.json.tag_name | regex_search('v([^v]*)', '\\1') | first }}"
 - name: "Ubuntu : Download latest version"
   ansible.builtin.get_url:
-    url: "https://github.com/jesseduffield/lazygit/releases/download/v{{ latest_version }}/lazygit_{{ latest_version }}_Linux_x86_64.tar.gz"
-    dest: "/tmp/lazygit-{{ latest_version }}.tar.gz"
+    url: "https://github.com/jesseduffield/lazygit/releases/download/v{{ lazygit_latest_version }}/lazygit_{{ lazygit_latest_version }}_Linux_x86_64.tar.gz"
+    dest: "/tmp/lazygit-{{ lazygit_latest_version }}.tar.gz"
     mode: "0644"
 - name: "Ubuntu : Extract and install binary"
   ansible.builtin.unarchive:
-    src: "/tmp/lazygit-{{ latest_version }}.tar.gz"
+    src: "/tmp/lazygit-{{ lazygit_latest_version }}.tar.gz"
     dest: "/usr/local/bin"
     remote_src: true
   become: true

--- a/roles/lazygit/tasks/main.yml
+++ b/roles/lazygit/tasks/main.yml
@@ -1,8 +1,9 @@
 ---
-- name: "Check for distribution config : {{ ansible_distribution }}"
+- name: "Check for distribution config : {{ ansible_facts['distribution'] }}"
   ansible.builtin.stat:
-    path: "{{ role_path }}/tasks/{{ ansible_distribution }}.yml"
-  register: distribution_config
-- name: "Run tasks : {{ ansible_distribution }}"
-  ansible.builtin.include_tasks: "{{ ansible_distribution }}.yml"
-  when: distribution_config.stat.exists
+    path: "{{ role_path }}/tasks/{{ ansible_facts['distribution'] }}.yml"
+  register: lazygit_distribution_config
+
+- name: "Run tasks : {{ ansible_facts['distribution'] }}"
+  ansible.builtin.include_tasks: "{{ ansible_facts['distribution'] }}.yml"
+  when: lazygit_distribution_config.stat.exists

--- a/roles/neovim/handlers/main.yml
+++ b/roles/neovim/handlers/main.yml
@@ -1,11 +1,17 @@
 ---
 - name: "Ubuntu : Clean, build and install"
-  ansible.builtin.shell: |
-    make distclean
-    make CMAKE_BUILD_TYPE=Release
-    make install
-  args:
-    chdir: "{{ neovim_repo_path }}"
-    executable: /bin/bash
-  become: true
-  changed_when: true
+  block:
+    - name: "Ubuntu : Clean-up dependencies"
+      community.general.make:
+        chdir: "{{ neovim_repo_path }}"
+        target: "distclean"
+    - name: "Ubuntu : Build"
+      community.general.make:
+        chdir: "{{ neovim_repo_path }}"
+        params:
+          CMAKE_BUILD_TYPE: Release
+    - name: "Ubuntu : Install"
+      community.general.make:
+        chdir: "{{ neovim_repo_path }}"
+        target: "install"
+      become: true

--- a/roles/neovim/handlers/main.yml
+++ b/roles/neovim/handlers/main.yml
@@ -1,0 +1,11 @@
+---
+- name: "Ubuntu : Clean, build and install"
+  ansible.builtin.shell: |
+    make distclean
+    make CMAKE_BUILD_TYPE=Release
+    make install
+  args:
+    chdir: "{{ neovim_repo_path }}"
+    executable: /bin/bash
+  become: true
+  changed_when: true

--- a/roles/neovim/tasks/Ubuntu.yml
+++ b/roles/neovim/tasks/Ubuntu.yml
@@ -14,21 +14,5 @@
     dest: "{{ neovim_repo_path }}"
     version: stable
     force: true
-  register: git_clone
-- name: "Ubuntu : Clean, build and install"
-  when: git_clone.changed
-  block:
-    - name: "Ubuntu : Clean-up dependencies"
-      community.general.make:
-        chdir: "{{ neovim_repo_path }}"
-        target: "distclean"
-    - name: "Ubuntu : Build"
-      community.general.make:
-        chdir: "{{ neovim_repo_path }}"
-        params:
-          CMAKE_BUILD_TYPE: Release
-    - name: "Ubuntu : Install"
-      community.general.make:
-        chdir: "{{ neovim_repo_path }}"
-        target: "install"
-      become: true
+  register: neovim_git_clone
+  notify: "Ubuntu : Clean, build and install"

--- a/roles/neovim/tasks/main.yml
+++ b/roles/neovim/tasks/main.yml
@@ -1,28 +1,28 @@
 ---
-- name: "Check for distribution config : {{ ansible_distribution }}"
+- name: "Check for distribution config : {{ ansible_facts['distribution'] }}"
   ansible.builtin.stat:
-    path: "{{ role_path }}/tasks/{{ ansible_distribution }}.yml"
-  register: distribution_config
-- name: "Run tasks : {{ ansible_distribution }}"
-  ansible.builtin.include_tasks: "{{ ansible_distribution }}.yml"
-  when: distribution_config.stat.exists
+    path: "{{ role_path }}/tasks/{{ ansible_facts['distribution'] }}.yml"
+  register: neovim_distribution_config
+- name: "Run tasks : {{ ansible_facts['distribution'] }}"
+  ansible.builtin.include_tasks: "{{ ansible_facts['distribution'] }}.yml"
+  when: neovim_distribution_config.stat.exists
 - name: "Check for existing config"
   ansible.builtin.stat:
-    dest: "{{ ansible_user_dir }}/.config/nvim"
-  register: nvim_config
+    dest: "{{ ansible_facts['user_dir'] }}/.config/nvim"
+  register: neovim_nvim_config
 - name: "Remove existing config"
   ansible.builtin.file:
-    path: "{{ ansible_user_dir }}/.config/nvim"
+    path: "{{ ansible_facts['user_dir'] }}/.config/nvim"
     state: absent
-  when: nvim_config.stat.islnk is defined and not nvim_config.stat.islnk
+  when: neovim_nvim_config.stat.islnk is defined and not neovim_nvim_config.stat.islnk
 - name: "Create config directory"
   ansible.builtin.file:
-    path: "{{ ansible_user_dir }}/.config"
+    path: "{{ ansible_facts['user_dir'] }}/.config"
     state: directory
     mode: "0755"
 - name: "Link config"
   ansible.builtin.file:
     src: "{{ role_path }}/files/nvim"
-    dest: "{{ ansible_user_dir }}/.config/nvim"
+    dest: "{{ ansible_facts['user_dir'] }}/.config/nvim"
     state: link
     force: true

--- a/roles/neovim/vars/main.yml
+++ b/roles/neovim/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-neovim_repo_path: "{{ ansible_user_dir }}/.nvim"
+neovim_repo_path: "{{ ansible_facts['user_dir'] }}/.nvim"

--- a/roles/python/tasks/main.yml
+++ b/roles/python/tasks/main.yml
@@ -1,11 +1,13 @@
 ---
-- name: "Check for distribution config : {{ ansible_distribution }}"
+- name: "Check for distribution config : {{ ansible_facts['distribution'] }}"
   ansible.builtin.stat:
-    path: "{{ role_path }}/tasks/{{ ansible_distribution }}.yml"
-  register: distribution_config
-- name: "Run tasks : {{ ansible_distribution }}"
-  ansible.builtin.include_tasks: "{{ ansible_distribution }}.yml"
-  when: distribution_config.stat.exists
+    path: "{{ role_path }}/tasks/{{ ansible_facts['distribution'] }}.yml"
+  register: python_distribution_config
+
+- name: "Run tasks : {{ ansible_facts['distribution'] }}"
+  ansible.builtin.include_tasks: "{{ ansible_facts['distribution'] }}.yml"
+  when: python_distribution_config.stat.exists
+
 - name: "Install uv"
   community.general.pipx:
     executable: pipx

--- a/roles/raycast/tasks/main.yml
+++ b/roles/raycast/tasks/main.yml
@@ -1,8 +1,9 @@
 ---
-- name: "Check for distribution config : {{ ansible_distribution }}"
+- name: "Check for distribution config : {{ ansible_facts['distribution'] }}"
   ansible.builtin.stat:
-    path: "{{ role_path }}/tasks/{{ ansible_distribution }}.yml"
-  register: distribution_config
-- name: "Run tasks : {{ ansible_distribution }}"
-  ansible.builtin.include_tasks: "{{ ansible_distribution }}.yml"
-  when: distribution_config.stat.exists
+    path: "{{ role_path }}/tasks/{{ ansible_facts['distribution'] }}.yml"
+  register: raycast_distribution_config
+
+- name: "Run tasks : {{ ansible_facts['distribution'] }}"
+  ansible.builtin.include_tasks: "{{ ansible_facts['distribution'] }}.yml"
+  when: raycast_distribution_config.stat.exists

--- a/roles/ripgrep/tasks/main.yml
+++ b/roles/ripgrep/tasks/main.yml
@@ -1,8 +1,9 @@
 ---
-- name: "Check for distribution config : {{ ansible_distribution }}"
+- name: "Check for distribution config : {{ ansible_facts['distribution'] }}"
   ansible.builtin.stat:
-    path: "{{ role_path }}/tasks/{{ ansible_distribution }}.yml"
-  register: distribution_config
-- name: "Run tasks : {{ ansible_distribution }}"
-  ansible.builtin.include_tasks: "{{ ansible_distribution }}.yml"
-  when: distribution_config.stat.exists
+    path: "{{ role_path }}/tasks/{{ ansible_facts['distribution'] }}.yml"
+  register: ripgrep_distribution_config
+
+- name: "Run tasks : {{ ansible_facts['distribution'] }}"
+  ansible.builtin.include_tasks: "{{ ansible_facts['distribution'] }}.yml"
+  when: ripgrep_distribution_config.stat.exists

--- a/roles/scroll_reverser/tasks/main.yml
+++ b/roles/scroll_reverser/tasks/main.yml
@@ -1,8 +1,9 @@
 ---
-- name: "Check for distribution config : {{ ansible_distribution }}"
+- name: "Check for distribution config : {{ ansible_facts['distribution'] }}"
   ansible.builtin.stat:
-    path: "{{ role_path }}/tasks/{{ ansible_distribution }}.yml"
-  register: distribution_config
-- name: "Run tasks : {{ ansible_distribution }}"
-  ansible.builtin.include_tasks: "{{ ansible_distribution }}.yml"
-  when: distribution_config.stat.exists
+    path: "{{ role_path }}/tasks/{{ ansible_facts['distribution'] }}.yml"
+  register: scroll_reverser_distribution_config
+
+- name: "Run tasks : {{ ansible_facts['distribution'] }}"
+  ansible.builtin.include_tasks: "{{ ansible_facts['distribution'] }}.yml"
+  when: scroll_reverser_distribution_config.stat.exists

--- a/roles/sesh/tasks/Ubuntu.yml
+++ b/roles/sesh/tasks/Ubuntu.yml
@@ -2,18 +2,18 @@
 - name: "Ubuntu : Check for latest version"
   ansible.builtin.uri:
     url: https://api.github.com/repos/joshmedeski/sesh/releases/latest
-  register: latest_version_response
+  register: sesh_latest_version_response
 - name: "Ubuntu : Set latest version"
   ansible.builtin.set_fact:
-    latest_version: "{{ latest_version_response.json.tag_name }}"
+    sesh_latest_version: "{{ sesh_latest_version_response.json.tag_name }}"
 - name: "Ubuntu : Download latest version"
   ansible.builtin.get_url:
-    url: "https://github.com/joshmedeski/sesh/releases/download/{{ latest_version }}/sesh_Linux_x86_64.tar.gz"
-    dest: "/tmp/sesh_{{ latest_version }}_Linux_x86_64.tar.gz"
+    url: "https://github.com/joshmedeski/sesh/releases/download/{{ sesh_latest_version }}/sesh_Linux_x86_64.tar.gz"
+    dest: "/tmp/sesh_{{ sesh_latest_version }}_Linux_x86_64.tar.gz"
     mode: "0644"
 - name: "Ubuntu : Extract and install binary"
   ansible.builtin.unarchive:
-    src: "/tmp/sesh_{{ latest_version }}_Linux_x86_64.tar.gz"
+    src: "/tmp/sesh_{{ sesh_latest_version }}_Linux_x86_64.tar.gz"
     dest: "/usr/local/bin"
     remote_src: true
   become: true

--- a/roles/sesh/tasks/main.yml
+++ b/roles/sesh/tasks/main.yml
@@ -1,8 +1,9 @@
 ---
-- name: "Check for distribution config : {{ ansible_distribution }}"
+- name: "Check for distribution config : {{ ansible_facts['distribution'] }}"
   ansible.builtin.stat:
-    path: "{{ role_path }}/tasks/{{ ansible_distribution }}.yml"
-  register: distribution_config
-- name: "Run tasks : {{ ansible_distribution }}"
-  ansible.builtin.include_tasks: "{{ ansible_distribution }}.yml"
-  when: distribution_config.stat.exists
+    path: "{{ role_path }}/tasks/{{ ansible_facts['distribution'] }}.yml"
+  register: sesh_distribution_config
+
+- name: "Run tasks : {{ ansible_facts['distribution'] }}"
+  ansible.builtin.include_tasks: "{{ ansible_facts['distribution'] }}.yml"
+  when: sesh_distribution_config.stat.exists

--- a/roles/ssh/tasks/main.yml
+++ b/roles/ssh/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
-- name: "Check for distribution config : {{ ansible_distribution }}"
+- name: "Check for distribution config : {{ ansible_facts['distribution'] }}"
   ansible.builtin.stat:
-    path: "{{ role_path }}/tasks/{{ ansible_distribution }}.yml"
-  register: distribution_config
-- name: "Run tasks : {{ ansible_distribution }}"
-  ansible.builtin.include_tasks: "{{ ansible_distribution }}.yml"
-  when: distribution_config.stat.exists
+    path: "{{ role_path }}/tasks/{{ ansible_facts['distribution'] }}.yml"
+  register: ssh_distribution_config
+- name: "Run tasks : {{ ansible_facts['distribution'] }}"
+  ansible.builtin.include_tasks: "{{ ansible_facts['distribution'] }}.yml"
+  when: ssh_distribution_config.stat.exists
 - name: "Check for SSH key"
   ansible.builtin.stat:
     path: "{{ ssh_key_path }}"
@@ -15,7 +15,7 @@
   block:
     - name: "Prompt for a SSH key comment"
       ansible.builtin.pause:
-        prompt: "SSH key comment [{{ ansible_user_id }}@{{ ansible_hostname }}]"
+        prompt: "SSH key comment [{{ ansible_facts['user_id'] }}@{{ ansible_facts['hostname'] }}]"
       register: ssh_key_comment
     - name: "Create ssh directory"
       ansible.builtin.file:
@@ -26,7 +26,7 @@
       community.crypto.openssh_keypair:
         type: "ed25519"
         path: "{{ ssh_key_path }}"
-        comment: "{{ ssh_key_comment.user_input | default(ansible_user_id + '@' + ansible_hostname, true) }}"
+        comment: "{{ ssh_key_comment.user_input | default(ansible_facts['user_id'] + '@' + ansible_facts['hostname'], true) }}"
     - name: "Print generated SSH public key"
       ansible.builtin.debug:
         msg: "{{ lookup('ansible.builtin.file', '{{ ssh_key_path }}.pub') }}"

--- a/roles/ssh/vars/main.yml
+++ b/roles/ssh/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-ssh_key_path: "{{ ansible_user_dir }}/.ssh/id_ed25519"
+ssh_key_path: "{{ ansible_facts['user_dir'] }}/.ssh/id_ed25519"

--- a/roles/tailscale/tasks/main.yml
+++ b/roles/tailscale/tasks/main.yml
@@ -1,8 +1,9 @@
 ---
-- name: "Check for distribution config : {{ ansible_distribution }}"
+- name: "Check for distribution config : {{ ansible_facts['distribution'] }}"
   ansible.builtin.stat:
-    path: "{{ role_path }}/tasks/{{ ansible_distribution }}.yml"
-  register: distribution_config
-- name: "Run tasks : {{ ansible_distribution }}"
-  ansible.builtin.include_tasks: "{{ ansible_distribution }}.yml"
-  when: distribution_config.stat.exists
+    path: "{{ role_path }}/tasks/{{ ansible_facts['distribution'] }}.yml"
+  register: tailscale_distribution_config
+
+- name: "Run tasks : {{ ansible_facts['distribution'] }}"
+  ansible.builtin.include_tasks: "{{ ansible_facts['distribution'] }}.yml"
+  when: tailscale_distribution_config.stat.exists

--- a/roles/tldr/tasks/main.yml
+++ b/roles/tldr/tasks/main.yml
@@ -1,8 +1,9 @@
 ---
-- name: "Check for distribution config : {{ ansible_distribution }}"
+- name: "Check for distribution config : {{ ansible_facts['distribution'] }}"
   ansible.builtin.stat:
-    path: "{{ role_path }}/tasks/{{ ansible_distribution }}.yml"
-  register: distribution_config
-- name: "Run tasks : {{ ansible_distribution }}"
-  ansible.builtin.include_tasks: "{{ ansible_distribution }}.yml"
-  when: distribution_config.stat.exists
+    path: "{{ role_path }}/tasks/{{ ansible_facts['distribution'] }}.yml"
+  register: tldr_distribution_config
+
+- name: "Run tasks : {{ ansible_facts['distribution'] }}"
+  ansible.builtin.include_tasks: "{{ ansible_facts['distribution'] }}.yml"
+  when: tldr_distribution_config.stat.exists

--- a/roles/tmux/tasks/main.yml
+++ b/roles/tmux/tasks/main.yml
@@ -1,19 +1,19 @@
 ---
-- name: "Check for distribution config : {{ ansible_distribution }}"
+- name: "Check for distribution config : {{ ansible_facts['distribution'] }}"
   ansible.builtin.stat:
-    path: "{{ role_path }}/tasks/{{ ansible_distribution }}.yml"
-  register: distribution_config
-- name: "Run tasks : {{ ansible_distribution }}"
-  ansible.builtin.include_tasks: "{{ ansible_distribution }}.yml"
-  when: distribution_config.stat.exists
+    path: "{{ role_path }}/tasks/{{ ansible_facts['distribution'] }}.yml"
+  register: tmux_distribution_config
+- name: "Run tasks : {{ ansible_facts['distribution'] }}"
+  ansible.builtin.include_tasks: "{{ ansible_facts['distribution'] }}.yml"
+  when: tmux_distribution_config.stat.exists
 - name: "Link config"
   ansible.builtin.file:
     src: "{{ role_path }}/files/.tmux.conf"
-    dest: "{{ ansible_user_dir }}/.tmux.conf"
+    dest: "{{ ansible_facts['user_dir'] }}/.tmux.conf"
     state: link
     force: true
 - name: "Install Tmux Plugin Manager"
   ansible.builtin.git:
     repo: "https://github.com/tmux-plugins/tpm"
-    dest: "{{ ansible_user_dir }}/.tmux/plugins/tpm"
+    dest: "{{ ansible_facts['user_dir'] }}/.tmux/plugins/tpm"
     version: master

--- a/roles/unzip/tasks/main.yml
+++ b/roles/unzip/tasks/main.yml
@@ -1,8 +1,9 @@
 ---
-- name: "Check for distribution config : {{ ansible_distribution }}"
+- name: "Check for distribution config : {{ ansible_facts['distribution'] }}"
   ansible.builtin.stat:
-    path: "{{ role_path }}/tasks/{{ ansible_distribution }}.yml"
-  register: distribution_config
-- name: "Run tasks : {{ ansible_distribution }}"
-  ansible.builtin.include_tasks: "{{ ansible_distribution }}.yml"
-  when: distribution_config.stat.exists
+    path: "{{ role_path }}/tasks/{{ ansible_facts['distribution'] }}.yml"
+  register: unzip_distribution_config
+
+- name: "Run tasks : {{ ansible_facts['distribution'] }}"
+  ansible.builtin.include_tasks: "{{ ansible_facts['distribution'] }}.yml"
+  when: unzip_distribution_config.stat.exists

--- a/roles/vscode/tasks/main.yml
+++ b/roles/vscode/tasks/main.yml
@@ -1,8 +1,9 @@
 ---
-- name: "Check for distribution config : {{ ansible_distribution }}"
+- name: "Check for distribution config : {{ ansible_facts['distribution'] }}"
   ansible.builtin.stat:
-    path: "{{ role_path }}/tasks/{{ ansible_distribution }}.yml"
-  register: distribution_config
-- name: "Run tasks : {{ ansible_distribution }}"
-  ansible.builtin.include_tasks: "{{ ansible_distribution }}.yml"
-  when: distribution_config.stat.exists
+    path: "{{ role_path }}/tasks/{{ ansible_facts['distribution'] }}.yml"
+  register: vscode_distribution_config
+
+- name: "Run tasks : {{ ansible_facts['distribution'] }}"
+  ansible.builtin.include_tasks: "{{ ansible_facts['distribution'] }}.yml"
+  when: vscode_distribution_config.stat.exists

--- a/roles/zoxide/tasks/main.yml
+++ b/roles/zoxide/tasks/main.yml
@@ -1,8 +1,9 @@
 ---
-- name: "Check for distribution config : {{ ansible_distribution }}"
+- name: "Check for distribution config : {{ ansible_facts['distribution'] }}"
   ansible.builtin.stat:
-    path: "{{ role_path }}/tasks/{{ ansible_distribution }}.yml"
-  register: distribution_config
-- name: "Run tasks : {{ ansible_distribution }}"
-  ansible.builtin.include_tasks: "{{ ansible_distribution }}.yml"
-  when: distribution_config.stat.exists
+    path: "{{ role_path }}/tasks/{{ ansible_facts['distribution'] }}.yml"
+  register: zoxide_distribution_config
+
+- name: "Run tasks : {{ ansible_facts['distribution'] }}"
+  ansible.builtin.include_tasks: "{{ ansible_facts['distribution'] }}.yml"
+  when: zoxide_distribution_config.stat.exists

--- a/roles/zsh/tasks/Ubuntu.yml
+++ b/roles/zsh/tasks/Ubuntu.yml
@@ -5,6 +5,6 @@
   become: true
 - name: "Ubuntu : Set default terminal"
   ansible.builtin.user:
-    name: "{{ ansible_user_id }}"
+    name: "{{ ansible_facts['user_id'] }}"
     shell: /usr/bin/zsh
   become: true

--- a/roles/zsh/tasks/main.yml
+++ b/roles/zsh/tasks/main.yml
@@ -1,64 +1,64 @@
 ---
-- name: "Check for distribution config : {{ ansible_distribution }}"
+- name: "Check for distribution config : {{ ansible_facts['distribution'] }}"
   ansible.builtin.stat:
-    path: "{{ role_path }}/tasks/{{ ansible_distribution }}.yml"
-  register: distribution_config
-- name: "Run tasks : {{ ansible_distribution }}"
-  ansible.builtin.include_tasks: "{{ ansible_distribution }}.yml"
-  when: distribution_config.stat.exists
+    path: "{{ role_path }}/tasks/{{ ansible_facts['distribution'] }}.yml"
+  register: zsh_distribution_config
+- name: "Run tasks : {{ ansible_facts['distribution'] }}"
+  ansible.builtin.include_tasks: "{{ ansible_facts['distribution'] }}.yml"
+  when: zsh_distribution_config.stat.exists
 - name: "Check Oh My Zsh installation status"
   ansible.builtin.stat:
-    path: "{{ lookup('ansible.builtin.env', 'ZSH') or ansible_user_dir + '/.oh-my-zsh' }}"
-  register: zsh
+    path: "{{ lookup('ansible.builtin.env', 'ZSH') or ansible_facts['user_dir'] + '/.oh-my-zsh' }}"
+  register: zsh_oh_my_zsh_stat
 - name: "Install Oh My Zsh"
   ansible.builtin.shell: sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --keep-zshrc
-  changed_when: not zsh.stat.exists
-  when: not zsh.stat.exists
+  changed_when: not zsh_oh_my_zsh_stat.stat.exists
+  when: not zsh_oh_my_zsh_stat.stat.exists
 - name: "Install zsh-autosuggestions"
   ansible.builtin.git:
     repo: "https://github.com/zsh-users/zsh-autosuggestions"
-    dest: "{{ lookup('ansible.builtin.env', 'ZSH_CUSTOM') or ansible_user_dir + '/.oh-my-zsh/custom' }}/plugins/zsh-autosuggestions"
+    dest: "{{ lookup('ansible.builtin.env', 'ZSH_CUSTOM') or ansible_facts['user_dir'] + '/.oh-my-zsh/custom' }}/plugins/zsh-autosuggestions"
     version: master
 - name: "Check for existing config"
   ansible.builtin.stat:
-    path: "{{ ansible_user_dir }}/.config/zsh"
+    path: "{{ ansible_facts['user_dir'] }}/.config/zsh"
   register: zsh_config
 - name: "Remove existing config"
   ansible.builtin.file:
-    path: "{{ ansible_user_dir }}/.config/zsh"
+    path: "{{ ansible_facts['user_dir'] }}/.config/zsh"
     state: absent
   when: zsh_config.stat.islnk is defined and not zsh_config.stat.islnk
 - name: "Create config directory"
   ansible.builtin.file:
-    path: "{{ ansible_user_dir }}/.config"
+    path: "{{ ansible_facts['user_dir'] }}/.config"
     state: directory
     mode: "0755"
 - name: "Link config"
   ansible.builtin.file:
     src: "{{ role_path }}/files/zsh"
-    dest: "{{ ansible_user_dir }}/.config/zsh"
+    dest: "{{ ansible_facts['user_dir'] }}/.config/zsh"
     state: link
 - name: "Get status of .zshrc"
   ansible.builtin.stat:
     path: "~/.zshrc"
-  register: zshrc
+  register: zsh_zshrc_stat
 - name: "Remove .zshrc if it is a link"
   ansible.builtin.file:
     path: "~/.zshrc"
     state: absent
-  when: zshrc.stat.islnk is defined and zshrc.stat.islnk
+  when: zsh_zshrc_stat.stat.islnk is defined and zsh_zshrc_stat.stat.islnk
 - name: "Ensure .zshrc exists"
   ansible.builtin.copy:
     content: ""
-    dest: "{{ ansible_user_dir }}/.zshrc"
-    force: no
+    dest: "{{ ansible_facts['user_dir'] }}/.zshrc"
+    force: false
     mode: "0644"
 - name: "Insert / update sourcing of .zshrc"
   ansible.builtin.blockinfile:
-    path: "{{ ansible_user_dir }}/.zshrc"
+    path: "{{ ansible_facts['user_dir'] }}/.zshrc"
     append_newline: true
     prepend_newline: true
     block: |
-      if [[ -f {{ ansible_user_dir }}/.config/zsh/.zshrc ]]; then
-        source {{ ansible_user_dir }}/.config/zsh/.zshrc
+      if [[ -f {{ ansible_facts['user_dir'] }}/.config/zsh/.zshrc ]]; then
+        source {{ ansible_facts['user_dir'] }}/.config/zsh/.zshrc
       fi


### PR DESCRIPTION
This PR updates the ansible config to fix deprecation notice warnings regarding to fact injection. This PR also fixes any warnings output by `ansible-lint`.
- Replace `ansible_{fact_name}` to `ansible_facts["{fact_name}"]`.
- Update variable names to be scoped to the task config.
- Move the multi step task block to a handler for nvim building and installation steps.